### PR TITLE
Notify IFQ download operations on Slack

### DIFF
--- a/app/adapters/dropbox.py
+++ b/app/adapters/dropbox.py
@@ -11,10 +11,16 @@ class DropboxAdapter:
         self.root_folder = root_folder
         self.client = dropbox.Dropbox(access_token)
 
-    def exists(self, key: str):
-        # print('checking for {folder}/{key}'.format(key=key, folder=self.root_folder))
-        return self.client.files_search(self.root_folder, key).matches
+    def exists(self, query: str) -> bool:
+        options = dropbox.files.SearchOptions(
+            path=self.root_folder
+        )
+        return len(self.client.files_search_v2(query, options).matches) > 0
 
     def put_file(self, file_path: str, file_name: str):
         with open(file_path, "rb") as f:
-            self.client.files_upload(f.read(), '%s/%s' % (self.root_folder, file_name), mute = True)
+            self.client.files_upload(
+                f.read(),
+                f'{self.root_folder}/{file_name}',
+                mute=True
+            )

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -38,26 +38,45 @@ command_handlers = {
     commands.Summarize: handlers.summarize,
 }
 
+event_handlers = {
+    events.RefurbishedProductAvailable: [
+        handlers.notify_refurbished_product_available
+    ],
+    events.TogglEntriesSummarized: [
+        handlers.notify_entries_summarized,
+    ],
+    events.IFQIssueAlreadyExists: [
+        handlers.log_event,
+        handlers.notify_ifq_issue_already_available,
+    ],
+    events.IFQIssueDownloaded: [
+        handlers.log_event,
+        handlers.notify_ifq_issue_downloaded,
+    ],
+    events.IFQIssueDownloadFailed: [
+        handlers.log_event,
+        handlers.notify_ifq_issue_download_failed,
+    ],
+}
+
 
 def for_cli():
     event_handlers = {
-        # events.EntriesSummarized: lambda event, uow: print(event.summary)
-        events.TogglEntriesSummarized: [handlers.log_entries_summarized],
-        events.IFQIssueAlreadyExists: [handlers.log_event],
-        events.IFQIssueDownloaded: [handlers.log_event],
-        events.IFQIssueDownloadFailed: [handlers.log_event],
+        events.TogglEntriesSummarized: [
+            handlers.log_entries_summarized,
+        ],
+        events.IFQIssueAlreadyExists: [
+            handlers.log_event,
+        ],
+        events.IFQIssueDownloaded: [
+            handlers.log_event,
+        ],
+        events.IFQIssueDownloadFailed: [
+            handlers.log_event,
+        ],
     }
     return MessageBus(uow, event_handlers, command_handlers)
 
 
 def for_lambda():
-    event_handlers = {
-        events.RefurbishedProductAvailable: [
-            handlers.notify_refurbished_product_available
-        ],
-        events.TogglEntriesSummarized: [handlers.notify_entries_summarized],
-        events.IFQIssueAlreadyExists: [handlers.log_event],
-        events.IFQIssueDownloaded: [handlers.log_event],
-        events.IFQIssueDownloadFailed: [handlers.log_event],
-    }
     return MessageBus(uow, event_handlers, command_handlers)

--- a/app/domain/events.py
+++ b/app/domain/events.py
@@ -24,6 +24,7 @@ class IFQIssueAlreadyExists(Event):
 class IFQIssueDownloadFailed(Event):
     filename: str
     error: Exception
+    traceback: str
 
 
 @dataclass

--- a/app/services/handlers.py
+++ b/app/services/handlers.py
@@ -128,3 +128,40 @@ def notify_refurbished_product_available(
 {event.text}
 """
     })
+
+
+def notify_ifq_issue_already_available(
+    event: events.IFQIssueAlreadyExists,
+    uow: UnitOfWork
+):
+    """Notify the event in a Slack channel"""
+
+    uow.slack.post_message({
+        'text': f'Hey, the IFQ issue named`{event.filename}`'
+        ' is already available.'
+    })
+
+
+def notify_ifq_issue_downloaded(
+    event: events.IFQIssueDownloaded,
+    uow: UnitOfWork
+):
+    """Notify the event in a Slack channel"""
+
+    uow.slack.post_message({
+        'text': f'Hey, the IFQ issue named `{event.filename}`'
+        ' has been downloaded successfully! 🎉'
+    })
+
+
+def notify_ifq_issue_download_failed(
+    event: events.IFQIssueDownloadFailed,
+    uow: UnitOfWork
+):
+    """Notify the event in a Slack channel"""
+
+    uow.slack.post_message({
+        'text': f"Hey, the download of the IFQ issue "
+        f"named `{event.filename}` is failed"
+        f" (`{event.error!r}`)."
+    })

--- a/cli/ifq-download.py
+++ b/cli/ifq-download.py
@@ -16,7 +16,7 @@ def run_ifq_download(day):
 
     cmd = DownloadIFQ(day)
 
-    messagebus = bootstrap.cli()
+    messagebus = bootstrap.for_cli()
     messagebus.handle(cmd)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,14 @@
-import os
 import json
 import pytest
 
-from app.adapters import apple, dropbox, ifq, slack, toggl
 from app import config
+from app.domain import events
+from app.adapters import apple, dropbox, ifq, slack, toggl
+from app.services import handlers
+from app.services.messagebus import MessageBus
 from app.services.unit_of_work import UnitOfWork
+from app import bootstrap
+
 
 # @pytest.fixture(scope="session")
 # def tmp_dir(tmpdir_factory):
@@ -95,6 +99,15 @@ def uow(toggl_adapter,
         dropbox_adapter,
         slack_adapter,
         refurbished_adapter
+    )
+
+
+@pytest.fixture(scope="function")
+def messagebus(uow):
+    return MessageBus(
+        uow,
+        bootstrap.event_handlers,
+        bootstrap.command_handlers,
     )
 
 

--- a/tests/integration/test_ifq.py
+++ b/tests/integration/test_ifq.py
@@ -1,0 +1,86 @@
+from datetime import date
+
+from app.adapters import dropbox, ifq, slack
+from app.domain import commands
+from app.services.messagebus import MessageBus
+
+
+def test_issue_is_already_available(
+    mocker,
+    messagebus: MessageBus,
+    dropbox_adapter: dropbox.DropboxAdapter,
+    slack_adapter: slack.SlackAdapter,
+):
+    mocker.patch.object(dropbox_adapter, 'exists')
+    dropbox_adapter.exists.side_effect = [True]
+
+    mocker.patch.object(slack_adapter, 'post_message')
+    slack_adapter.post_message.side_effect = [None]
+
+    cmd = commands.DownloadIFQ(day=date(2020, 7, 30))
+
+    messagebus.handle(cmd)
+
+    message = {
+        'text': "Hey, the IFQ issue named`ilfatto-20200730.pdf`"
+        " is already available."
+    }
+    slack_adapter.post_message.assert_called_once_with(
+        message
+    )
+
+
+def test_ifq_issue_downloaded(
+    mocker,
+    messagebus: MessageBus,
+    dropbox_adapter: dropbox.DropboxAdapter,
+    ifq_adapter: ifq.IFQAdapter,
+    slack_adapter: slack.SlackAdapter,
+):
+    mocker.patch.object(dropbox_adapter, 'exists')
+    mocker.patch.object(dropbox_adapter, 'put_file')
+    mocker.patch.object(ifq_adapter, 'download_pdf')
+    dropbox_adapter.exists.side_effect = [False]
+    dropbox_adapter.put_file.side_effect = [None]
+    ifq_adapter.download_pdf.side_effect = ['/some/path']
+
+    mocker.patch.object(slack_adapter, 'post_message')
+    slack_adapter.post_message.side_effect = [None]
+
+    cmd = commands.DownloadIFQ(day=date(2020, 7, 30))
+
+    messagebus.handle(cmd)
+
+    message = {
+        'text': "Hey, the IFQ issue named `ilfatto-20200730.pdf` "
+        "has been downloaded successfully! 🎉"
+    }
+    slack_adapter.post_message.assert_called_once_with(
+        message
+    )
+
+
+def test_ifq_issue_download_failed(
+    mocker,
+    messagebus: MessageBus,
+    dropbox_adapter: dropbox.DropboxAdapter,
+    slack_adapter: slack.SlackAdapter,
+):
+    mocker.patch.object(dropbox_adapter, 'exists')
+    dropbox_adapter.exists.side_effect = Exception("ka-booom!")
+
+    mocker.patch.object(slack_adapter, 'post_message')
+    slack_adapter.post_message.side_effect = [None]
+
+    cmd = commands.DownloadIFQ(day=date(2020, 7, 30))
+
+    messagebus.handle(cmd)
+
+    message = {
+        'text': "Hey, the download of the IFQ issue "
+        "named `ilfatto-20200730.pdf` is failed"
+        " (`Exception('ka-booom!')`)."
+    }
+    slack_adapter.post_message.assert_called_once_with(
+        message
+    )

--- a/tests/integration/test_slash_commands.py
+++ b/tests/integration/test_slash_commands.py
@@ -73,6 +73,7 @@ def test_slash_commands_without_text(
 no-text.json'
     )
     mocker.patch.object(slack_adapter, "post_message")
+    slack_adapter.post_message.side_effect = [None]
 
     resp = run_slash_command(event, None)
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
I have no clue if IFQ download operation went well or not during the night.

### Change description
<!-- What does your code do? -->

Add new event handlers for the major event from IFQ:
 * `IFQIssueDownloaded`
 * `IFQIssueAlreadyExists`
 * `IFQIssueDownloadFailed`

and sends a Slack notification on the channel `#general` for each of them.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

Implements #42 

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.