### PR TITLE
Properly handle conversations on Slack

### DIFF
--- a/app/services/handlers.py
+++ b/app/services/handlers.py
@@ -1,6 +1,6 @@
 import datetime
 import traceback
-from typing import List
+from typing import Any, Dict, List
 
 from humanize import naturaldelta
 
@@ -9,7 +9,11 @@ from app.domain import commands, events
 from app.services.unit_of_work import UnitOfWork
 
 
-def summarize(cmd: commands.Summarize, uow: UnitOfWork) -> List[events.Event]:
+def summarize(
+    cmd: commands.Summarize,
+    uow: UnitOfWork,
+    context: Dict[str, Any],
+) -> List[events.Event]:
     """Summarize the toggl entries for a given day"""
     with uow:
         summary = uow.toggl.summary(cmd.day, cmd.day)
@@ -44,7 +48,8 @@ def summarize(cmd: commands.Summarize, uow: UnitOfWork) -> List[events.Event]:
 
 def check_refurbished(
     cmd: commands.CheckRefurbished,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ) -> List[events.Event]:
     """Checks the refurbished section of the Apple Store looking for deals."""
     with uow:
@@ -71,7 +76,8 @@ def check_refurbished(
 
 def download_ifq(
     cmd: commands.DownloadIFQ,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ) -> List[events.Event]:
     FILENAME_PATTERN = 'ilfatto-%Y%m%d.pdf'
     try:
@@ -97,7 +103,8 @@ def download_ifq(
 
 def log_entries_summarized(
     event: events.TogglEntriesSummarized,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ):
     """Logs the event in the termimal"""
     terminal.log(event.summary)
@@ -105,7 +112,8 @@ def log_entries_summarized(
 
 def log_event(
     event: events.Event,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ):
     """"Logs events"""
     text = str(event)
@@ -114,7 +122,8 @@ def log_event(
 
 def notify_entries_summarized(
     event: events.TogglEntriesSummarized,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ):
     """Notify the event in a Slack channel"""
 
@@ -124,12 +133,13 @@ def notify_entries_summarized(
 {event.summary}
 ```
 """
-    })
+    }, context)
 
 
 def notify_refurbished_product_available(
     event: events.RefurbishedProductAvailable,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ):
     """Notify the event in a Slack channel"""
 
@@ -137,48 +147,52 @@ def notify_refurbished_product_available(
         'text': f"""
 {event.text}
 """
-    })
+    }, context)
 
 
 def notify_refurbished_product_not_available(
     event: events.RefurbishedProductNotAvailable,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ):
     """Notify the event in a Slack channel"""
 
     uow.slack.post_message({
         'text': f"Hey, can't find any '{event.product}' "
         f"in the '{event.store}' store now 🤔"
-    })
+    }, context)
 
 
 def notify_ifq_issue_already_available(
     event: events.IFQIssueAlreadyExists,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ):
     """Notify the event in a Slack channel"""
 
     uow.slack.post_message({
         'text': f'Hey, the IFQ issue named`{event.filename}`'
         ' is already available.'
-    })
+    }, context)
 
 
 def notify_ifq_issue_downloaded(
     event: events.IFQIssueDownloaded,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ):
     """Notify the event in a Slack channel"""
 
     uow.slack.post_message({
         'text': f'Hey, the IFQ issue named `{event.filename}`'
         ' has been downloaded successfully! 🎉'
-    })
+    }, context)
 
 
 def notify_ifq_issue_download_failed(
     event: events.IFQIssueDownloadFailed,
-    uow: UnitOfWork
+    uow: UnitOfWork,
+    context: Dict[str, Any],
 ):
     """Notify the event in a Slack channel"""
 
@@ -186,4 +200,4 @@ def notify_ifq_issue_download_failed(
         'text': f"Hey, the download of the IFQ issue "
         f"named `{event.filename}` is failed"
         f" (`{event.error!r}`)."
-    })
+    }, context)

--- a/cli/check-refurbished.py
+++ b/cli/check-refurbished.py
@@ -22,7 +22,7 @@ def run_command(store: str, product: str):
     )
 
     messagebus = bootstrap.for_cli()
-    messagebus.handle(cmd)
+    messagebus.handle(cmd, {})
 
 
 if __name__ == '__main__':

--- a/cli/ifq-download.py
+++ b/cli/ifq-download.py
@@ -17,7 +17,7 @@ def run_command(day):
     cmd = DownloadIFQ(day=day)
 
     messagebus = bootstrap.for_cli()
-    messagebus.handle(cmd)
+    messagebus.handle(cmd, {})
 
 
 if __name__ == '__main__':

--- a/cli/summarize.py
+++ b/cli/summarize.py
@@ -17,7 +17,7 @@ def run_command(day):
     cmd = Summarize(day=day)
 
     messagebus = bootstrap.for_cli()
-    messagebus.handle(cmd)
+    messagebus.handle(cmd, {})
 
 
 if __name__ == '__main__':

--- a/tests/data/aws/sns/events/publish/check-refurbished.json
+++ b/tests/data/aws/sns/events/publish/check-refurbished.json
@@ -19,6 +19,10 @@
                     "type-command": {
                         "Type": "String",
                         "Value": "CheckRefurbished"
+                    },
+                    "context": {
+                        "Type": "String",
+                        "Value": "{}"
                     }
                 }
             }

--- a/tests/integration/test_context.py
+++ b/tests/integration/test_context.py
@@ -1,0 +1,32 @@
+from app.adapters import apple, slack
+from app.domain import commands
+from app.services import messagebus
+
+
+def test_unavailable_products(
+    mocker,
+    messagebus: messagebus.MessageBus,
+    refurbished_adapter: apple.RefurbishedStoreAdapter,
+    slack_adapter: slack.SlackAdapter,
+):
+    mocker.patch.object(refurbished_adapter, "search")
+    refurbished_adapter.search.side_effect = [[]]
+
+    mocker.patch.object(slack_adapter, 'post_message')
+    slack_adapter.post_message.side_effect = [None]
+
+    cmd = commands.CheckRefurbished(store='it', products=['ipad'])
+    ctx = {
+        "slack": {
+            "response_url": "https://stocazzo.net",
+        }
+    }
+
+    messagebus.handle(cmd, ctx)
+
+    message = {
+        'text': "Hey, can't find any 'ipad' in the 'it' store now 🤔"
+    }
+    slack_adapter.post_message.assert_called_once_with(
+       message, ctx
+    )

--- a/tests/integration/test_ifq.py
+++ b/tests/integration/test_ifq.py
@@ -19,14 +19,14 @@ def test_issue_is_already_available(
 
     cmd = commands.DownloadIFQ(day=date(2020, 7, 30))
 
-    messagebus.handle(cmd)
+    messagebus.handle(cmd, {})
 
     message = {
         'text': "Hey, the IFQ issue named`ilfatto-20200730.pdf`"
         " is already available."
     }
     slack_adapter.post_message.assert_called_once_with(
-        message
+        message, {}
     )
 
 
@@ -49,14 +49,14 @@ def test_ifq_issue_downloaded(
 
     cmd = commands.DownloadIFQ(day=date(2020, 7, 30))
 
-    messagebus.handle(cmd)
+    messagebus.handle(cmd, {})
 
     message = {
         'text': "Hey, the IFQ issue named `ilfatto-20200730.pdf` "
         "has been downloaded successfully! 🎉"
     }
     slack_adapter.post_message.assert_called_once_with(
-        message
+        message, {}
     )
 
 
@@ -74,7 +74,7 @@ def test_ifq_issue_download_failed(
 
     cmd = commands.DownloadIFQ(day=date(2020, 7, 30))
 
-    messagebus.handle(cmd)
+    messagebus.handle(cmd, {})
 
     message = {
         'text': "Hey, the download of the IFQ issue "
@@ -82,5 +82,5 @@ def test_ifq_issue_download_failed(
         " (`Exception('ka-booom!')`)."
     }
     slack_adapter.post_message.assert_called_once_with(
-        message
+        message, {}
     )

--- a/tests/integration/test_refurbished.py
+++ b/tests/integration/test_refurbished.py
@@ -38,7 +38,7 @@ def test_available_products(
 
     # bus.add_event_handler(type(cmd))
     cmd = commands.CheckRefurbished(store='it', products=['ipad'])
-    actual_events = handlers.check_refurbished(cmd, uow)
+    actual_events = handlers.check_refurbished(cmd, uow, {})
 
     # print('actual_events', actual_events)
     assert actual_events, "no events generated"
@@ -66,11 +66,11 @@ def test_unavailable_products(
 
     cmd = commands.CheckRefurbished(store='it', products=['ipad'])
 
-    messagebus.handle(cmd)
+    messagebus.handle(cmd, {})
 
     message = {
         'text': "Hey, can't find any 'ipad' in the 'it' store now 🤔"
     }
     slack_adapter.post_message.assert_called_once_with(
-        message
+        message, {}
     )

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -22,7 +22,7 @@ Oooops, there are no entries here ¯\\_(ツ)_/¯
 
     cmd = Summarize(day=date(2020, 6, 25))
 
-    actual_events = summarize(cmd, uow)
+    actual_events = summarize(cmd, uow, {})
 
     assert len(actual_events) == len(expected_events)
     assert actual_events[0].summary == expected_events[0].summary
@@ -58,7 +58,7 @@ Here's the summary for Thursday, June 25 2020
 
     cmd = Summarize(day=date(2020, 6, 25))
 
-    actual_events = summarize(cmd, uow)
+    actual_events = summarize(cmd, uow, {})
 
     assert len(actual_events) == len(expected_events)
     assert actual_events[0].summary == expected_events[0].summary

--- a/tests/integration/test_slash_commands.py
+++ b/tests/integration/test_slash_commands.py
@@ -1,10 +1,7 @@
-import decimal
 import logging
 
-from refurbished.parser import Product
-
 from app.entrypoints.aws.api_gateway.slash_commands import dispatch, sns
-from app.bootstrap import refurbished_adapter, slack_adapter
+from app.bootstrap import slack_adapter
 
 
 def test_slash_commands_with_an_invalid_token(from_json):

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -33,5 +33,5 @@ def test_check_refurbished_products_triggered_by_a_sns_notification(
         'text': "Hey, can't find any 'ipad' in the 'it' store now 🤔"
     }
     slack_adapter.post_message.assert_called_once_with(
-        message
+        message, {}
     )

--- a/tests/unit/test_event_logger.py
+++ b/tests/unit/test_event_logger.py
@@ -7,7 +7,7 @@ def test_log_event_as_text(mocker, uow):
     spy = mocker.spy(terminal, "log")
 
     event = events.IFQIssueDownloaded(filename="ilfatto-2020-07-23.pdf")
-    handlers.log_event(event, uow)
+    handlers.log_event(event, uow, {})
 
     spy.assert_called_once_with(
         "IFQIssueDownloaded(filename='ilfatto-2020-07-23.pdf')"

--- a/tests/unit/test_slash_command_dispatcher.py
+++ b/tests/unit/test_slash_command_dispatcher.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from app.adapters.slack import build_slash_command, SlashCommandDispatcher
 
 
@@ -8,7 +10,7 @@ dispatcher = SlashCommandDispatcher()
     "/refurbished",
     text_regex="(?P<store>it|us) (?P<product>ipad|iphone|mac)"
 )
-def check_refurbished(store: str, product: str):
+def check_refurbished(context: Dict[str, Any], store: str, product: str):
     assert store == 'it'
     assert product == 'mac'
 
@@ -19,7 +21,7 @@ def test_simple_command(from_json):
     )
 
     dispatcher.dispatch(
-        build_slash_command(event["body"])
+        build_slash_command(event["body"]), {}
     )
 
     # should not raise any exception


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
When a user sends a slash message, the response is always sent back to the `#general` channel in Slack. It would be far better to respond in the same conversation (DM or channel) the slash command was sent from.

### Change description
<!-- What does your code do? -->
Add a new optional `context` dictionary that entry points can fill with some data that can be used downstream. 

In the demo implementation, the slash command entry point add some user info in the context that the Slack adapter later use to send the response the the most appropriate recipient.

I'm not completely sure this is the right solution, but is simple enough to be changed or removed later if necessary and it works.

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.