### PR TITLE
Slack: Toggl summarize slash command accepts a date

### DIFF
--- a/app/adapters/slack.py
+++ b/app/adapters/slack.py
@@ -119,11 +119,8 @@ class SlashCommandDispatcher:
             )
             route.handler(context, **args)
         else:
-            # call the command handler
-            if cmd.text:
-                route.handler(context, cmd.text) 
-            else:
-                route.handler(context)
+            # call the command handler passing the text
+            route.handler(context, cmd.text)
 
 
 def build_slash_command(qs: str) -> SlashCommand:

--- a/app/adapters/slack.py
+++ b/app/adapters/slack.py
@@ -113,11 +113,17 @@ class SlashCommandDispatcher:
 
             # call the command handler
             args = match.groupdict()
-            logger.info(f'handing off cmd {cmd.name} to {route.handler} with context {context} args {args}')
+            logger.info(
+                f'handing off cmd {cmd.name} to {route.handler}'
+                ' with context {context} args {args}'
+            )
             route.handler(context, **args)
         else:
             # call the command handler
-            route.handler(context)
+            if cmd.text:
+                route.handler(context, cmd.text) 
+            else:
+                route.handler(context)
 
 
 def build_slash_command(qs: str) -> SlashCommand:
@@ -174,7 +180,6 @@ def verify_signature(body: str, headers: Dict[str, str]):
     ).hexdigest()
 
     if not hmac.compare_digest(request_hash, signature):
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f'expected: {signature}')
-            logger.debug(f'actual: {request_hash}')
+        logger.warning(f'expected: {signature}')
+        logger.warning(f'actual: {request_hash}')
         raise InvalidSignature()

--- a/app/adapters/slack.py
+++ b/app/adapters/slack.py
@@ -115,7 +115,7 @@ class SlashCommandDispatcher:
             args = match.groupdict()
             logger.info(
                 f'handing off cmd {cmd.name} to {route.handler}'
-                ' with context {context} args {args}'
+                f' with context {context} args {args}'
             )
             route.handler(context, **args)
         else:

--- a/app/entrypoints/aws/api_gateway/slash_commands.py
+++ b/app/entrypoints/aws/api_gateway/slash_commands.py
@@ -2,7 +2,7 @@ import json
 import logging
 from typing import Any, Dict
 
-from datetime import date
+from datetime import date, datetime
 
 from app import config
 from app.adapters import aws, slack
@@ -24,7 +24,11 @@ sns = aws.SNSCommandPublisher(
     "/refurbished",
     text_regex="(?P<store>it|us|uk|au) (?P<product>ipad|iphone|mac)"
 )
-def check_refurbished(context: Dict[str, Any], store: str, product: str):
+def check_refurbished(
+    context: Dict[str, Any],
+    store: str,
+    product: str
+):
     resp = sns.publish(
         commands.CheckRefurbished(
             store=store,
@@ -38,10 +42,13 @@ def check_refurbished(context: Dict[str, Any], store: str, product: str):
 @dispatcher.route(
     "/summarize"
 )
-def summarize(context: Dict[str, Any]):
+def summarize(context: Dict[str, Any], text: str = None):
+
+    day = datetime.strptime(text, '%Y-%m-%d') if text else date.today()
+
     resp = sns.publish(
         commands.Summarize(
-            day=date.today()
+            day=day
         ),
         context,
     )

--- a/app/entrypoints/aws/cloudwatch/events.py
+++ b/app/entrypoints/aws/cloudwatch/events.py
@@ -41,4 +41,4 @@ def run_scheduled(event, config):
     else:
         return
 
-    messagebus.handle(cmd)
+    messagebus.handle(cmd, {})

--- a/tests/data/aws/lambda/events/api-gateway/slack/slash-commands/summarize-with-date.json
+++ b/tests/data/aws/lambda/events/api-gateway/slack/slash-commands/summarize-with-date.json
@@ -1,0 +1,121 @@
+{
+    "resource": "/v1/integrations/slack/slash-commands",
+    "path": "/v1/integrations/slack/slash-commands",
+    "httpMethod": "POST",
+    "headers": {
+        "Accept": "application/json,*/*",
+        "Accept-Encoding": "gzip,deflate",
+        "CloudFront-Forwarded-Proto": "https",
+        "CloudFront-Is-Desktop-Viewer": "true",
+        "CloudFront-Is-Mobile-Viewer": "false",
+        "CloudFront-Is-SmartTV-Viewer": "false",
+        "CloudFront-Is-Tablet-Viewer": "false",
+        "CloudFront-Viewer-Country": "US",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Host": "example.com",
+        "User-Agent": "Slackbot 1.0 (+https://api.slack.com/robots)",
+        "Via": "1.1 7f7e359e1c06a914d3d305785359b84d.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Id": "wIHxsLF7aX-vbxGEINWkxUPCA2asRUOyRop5ANYBh7CZ7O6N1gp7iQ==",
+        "X-Amzn-Trace-Id": "Root=1-5f1e6831-a7b63776df4cc9a8e9355066",
+        "X-Forwarded-For": "54.196.39.209, 70.132.33.95",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https",
+        "X-Slack-Request-Timestamp": "1595828273",
+        "X-Slack-Signature": "v0=39edb6d769cbf698027d8ed337de40b688077acd72c66ca892c3976325c1381a"
+    },
+    "multiValueHeaders": {
+        "Accept": [
+            "application/json,*/*"
+        ],
+        "Accept-Encoding": [
+            "gzip,deflate"
+        ],
+        "CloudFront-Forwarded-Proto": [
+            "https"
+        ],
+        "CloudFront-Is-Desktop-Viewer": [
+            "true"
+        ],
+        "CloudFront-Is-Mobile-Viewer": [
+            "false"
+        ],
+        "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+        ],
+        "CloudFront-Is-Tablet-Viewer": [
+            "false"
+        ],
+        "CloudFront-Viewer-Country": [
+            "US"
+        ],
+        "Content-Type": [
+            "application/x-www-form-urlencoded"
+        ],
+        "Host": [
+            "tk64fyptexample.com"
+        ],
+        "User-Agent": [
+            "Slackbot 1.0 (+https://api.slack.com/robots)"
+        ],
+        "Via": [
+            "1.1 7f7e359e1c06a914d3d305785359b84d.cloudfront.net (CloudFront)"
+        ],
+        "X-Amz-Cf-Id": [
+            "wIHxsLF7aX-vbxGEINWkxUPCA2asRUOyRop5ANYBh7CZ7O6N1gp7iQ=="
+        ],
+        "X-Amzn-Trace-Id": [
+            "Root=1-5f1e6831-a7b63776df4cc9a8e9355066"
+        ],
+        "X-Forwarded-For": [
+            "54.196.39.209, 70.132.33.95"
+        ],
+        "X-Forwarded-Port": [
+            "443"
+        ],
+        "X-Forwarded-Proto": [
+            "https"
+        ],
+        "X-Slack-Request-Timestamp": [
+            "1595828273"
+        ],
+        "X-Slack-Signature": [
+            "v0=8f62496c1f63b47e0ee797b00500abfc8b08fe01bc1b39a9434e02c56140c508"
+        ]
+    },
+    "queryStringParameters": null,
+    "multiValueQueryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "resourceId": "z6ya6r",
+        "resourcePath": "/v1/integrations/slack/slash-commands",
+        "httpMethod": "POST",
+        "extendedRequestId": "QUU30HTyjoEFolg=",
+        "requestTime": "27/Jul/2020:05:37:53 +0000",
+        "path": "/dev/v1/integrations/slack/slash-commands",
+        "accountId": "418425532336",
+        "protocol": "HTTP/1.1",
+        "stage": "dev",
+        "domainPrefix": "tk64fyptcj",
+        "requestTimeEpoch": 1595828273917,
+        "requestId": "57edf154-517c-45c1-9555-6764e48bd357",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "sourceIp": "54.196.39.209",
+            "principalOrgId": null,
+            "accessKey": null,
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "Slackbot 1.0 (+https://api.slack.com/robots)",
+            "user": null
+        },
+        "domainName": "example.com",
+        "apiId": "tk64fyptcj"
+    },
+    "body": "token=xxx&team_id=T02RX18RT&team_domain=zmoog&channel_id=DN95R50BA&channel_name=directmessage&user_id=U02RX18RV&user_name=zmoog&command=%2Fsummarize&text=2020-08-06&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02RX18RT%2F1287752509456%2FRvnHleL1XCLxuMU2zGDGRbtT&trigger_id=1270097955124.2881042877.121a0b3a9cf1313830907fcdde478152",
+    "isBase64Encoded": false
+}

--- a/tests/data/aws/lambda/events/api-gateway/slack/slash-commands/summarize-without-date.json
+++ b/tests/data/aws/lambda/events/api-gateway/slack/slash-commands/summarize-without-date.json
@@ -1,0 +1,121 @@
+{
+    "resource": "/v1/integrations/slack/slash-commands",
+    "path": "/v1/integrations/slack/slash-commands",
+    "httpMethod": "POST",
+    "headers": {
+        "Accept": "application/json,*/*",
+        "Accept-Encoding": "gzip,deflate",
+        "CloudFront-Forwarded-Proto": "https",
+        "CloudFront-Is-Desktop-Viewer": "true",
+        "CloudFront-Is-Mobile-Viewer": "false",
+        "CloudFront-Is-SmartTV-Viewer": "false",
+        "CloudFront-Is-Tablet-Viewer": "false",
+        "CloudFront-Viewer-Country": "US",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Host": "example.com",
+        "User-Agent": "Slackbot 1.0 (+https://api.slack.com/robots)",
+        "Via": "1.1 7f7e359e1c06a914d3d305785359b84d.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Id": "wIHxsLF7aX-vbxGEINWkxUPCA2asRUOyRop5ANYBh7CZ7O6N1gp7iQ==",
+        "X-Amzn-Trace-Id": "Root=1-5f1e6831-a7b63776df4cc9a8e9355066",
+        "X-Forwarded-For": "54.196.39.209, 70.132.33.95",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https",
+        "X-Slack-Request-Timestamp": "1595828273",
+        "X-Slack-Signature": "v0=0ff3751d3f4520b087c1a598447541e302d68a3dd46ae6f238ff14a3d97617a9"
+    },
+    "multiValueHeaders": {
+        "Accept": [
+            "application/json,*/*"
+        ],
+        "Accept-Encoding": [
+            "gzip,deflate"
+        ],
+        "CloudFront-Forwarded-Proto": [
+            "https"
+        ],
+        "CloudFront-Is-Desktop-Viewer": [
+            "true"
+        ],
+        "CloudFront-Is-Mobile-Viewer": [
+            "false"
+        ],
+        "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+        ],
+        "CloudFront-Is-Tablet-Viewer": [
+            "false"
+        ],
+        "CloudFront-Viewer-Country": [
+            "US"
+        ],
+        "Content-Type": [
+            "application/x-www-form-urlencoded"
+        ],
+        "Host": [
+            "tk64fyptexample.com"
+        ],
+        "User-Agent": [
+            "Slackbot 1.0 (+https://api.slack.com/robots)"
+        ],
+        "Via": [
+            "1.1 7f7e359e1c06a914d3d305785359b84d.cloudfront.net (CloudFront)"
+        ],
+        "X-Amz-Cf-Id": [
+            "wIHxsLF7aX-vbxGEINWkxUPCA2asRUOyRop5ANYBh7CZ7O6N1gp7iQ=="
+        ],
+        "X-Amzn-Trace-Id": [
+            "Root=1-5f1e6831-a7b63776df4cc9a8e9355066"
+        ],
+        "X-Forwarded-For": [
+            "54.196.39.209, 70.132.33.95"
+        ],
+        "X-Forwarded-Port": [
+            "443"
+        ],
+        "X-Forwarded-Proto": [
+            "https"
+        ],
+        "X-Slack-Request-Timestamp": [
+            "1595828273"
+        ],
+        "X-Slack-Signature": [
+            "v0=8f62496c1f63b47e0ee797b00500abfc8b08fe01bc1b39a9434e02c56140c508"
+        ]
+    },
+    "queryStringParameters": null,
+    "multiValueQueryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "resourceId": "z6ya6r",
+        "resourcePath": "/v1/integrations/slack/slash-commands",
+        "httpMethod": "POST",
+        "extendedRequestId": "QUU30HTyjoEFolg=",
+        "requestTime": "27/Jul/2020:05:37:53 +0000",
+        "path": "/dev/v1/integrations/slack/slash-commands",
+        "accountId": "418425532336",
+        "protocol": "HTTP/1.1",
+        "stage": "dev",
+        "domainPrefix": "tk64fyptcj",
+        "requestTimeEpoch": 1595828273917,
+        "requestId": "57edf154-517c-45c1-9555-6764e48bd357",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "sourceIp": "54.196.39.209",
+            "principalOrgId": null,
+            "accessKey": null,
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "Slackbot 1.0 (+https://api.slack.com/robots)",
+            "user": null
+        },
+        "domainName": "example.com",
+        "apiId": "tk64fyptcj"
+    },
+    "body": "token=xxx&team_id=T02RX18RT&team_domain=zmoog&channel_id=DN95R50BA&channel_name=directmessage&user_id=U02RX18RV&user_name=zmoog&command=%2Fsummarize&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02RX18RT%2F1287752509456%2FRvnHleL1XCLxuMU2zGDGRbtT&trigger_id=1270097955124.2881042877.121a0b3a9cf1313830907fcdde478152",
+    "isBase64Encoded": false
+}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Current version of `/summarize` slash command always summarize the current day. It would be better to optionally accept a date to summarize.

For example:
```
/summarize — just summarize today's entries
/summarize 2020-8-1 — summarize August, 1st 2020 entries
```

### Change description
<!-- What does your code do? -->
The `SlashCommandDispatcher` now passes the `text` field to the handlers so they can use it. Text is passed only for handler configured without a pattern.

Now the `summarize` slash command handler can parse the `text` and summarize for a specific day.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
Implements #52 

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.