### PR TITLE
Refurbished: add product URL

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,7 @@ humanize = "==2.5.0"
 click = "==7.1.2"
 python-dateutil = "==2.8.1"
 pydantic = "==1.6.1"
-refurbished = {editable = true,git = "https://github.com/zmoog/refurbished.git",ref = "v0.2.0-pre"}
+refurbished = {editable = true,git = "https://github.com/zmoog/refurbished.git",ref = "v0.3.0"}
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "482698119e0851aca2f4ff4263ff2a600d9f255fb3cdce064d45b105ef0c7f46"
+            "sha256": "b2a687ea1a191f92fac797877e9f32479b011f130f51fcba2a88b379811f2730"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a",
+                "sha256:2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff"
             ],
-            "version": "==19.3.0"
+            "version": "==20.1.0"
         },
         "certifi": {
             "hashes": [
@@ -147,7 +147,7 @@
         "refurbished": {
             "editable": true,
             "git": "https://github.com/zmoog/refurbished.git",
-            "ref": "acda1c65bcb1d379e67f35b5d3f5c734e7125dbe"
+            "ref": "033ab3c0e67b5fc4be7c756d16d20582a5d2c4aa"
         },
         "requests": {
             "hashes": [
@@ -175,10 +175,10 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a",
+                "sha256:2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff"
             ],
-            "version": "==19.3.0"
+            "version": "==20.1.0"
         },
         "boto3": {
             "hashes": [
@@ -190,10 +190,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:b869be5ca327bdf64d4e203f3bb6036cc9700e1cb55c8633779f74e0658d5d06",
-                "sha256:fd1c42436a4271fbcc8bc53357171ff01d9a1bea8efc4c8a00e58a531efdcb31"
+                "sha256:0b23b519ec10193d1ead1cbb1469e7ede80789b068b74575b4efb06619e8e457",
+                "sha256:db9cd219d4180e782615179950e16b43d13e2f3fa57f510a43bf4ed5a3a8dacb"
             ],
-            "version": "==1.17.39"
+            "version": "==1.17.48"
         },
         "docutils": {
             "hashes": [
@@ -298,11 +298,11 @@
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:5564c7cd2569b603f8451ec77928083054d8896046830ca763ed68f4112d17c7",
-                "sha256:7122d55505d5ed5a6f3df940ad174b3f606ecae5e9bc379569cdcbd4cd9d2b83"
+                "sha256:0061f9e8f14b77d0f3915a00f18b1b71f07da3c8bd66994e42ee91537681a76e",
+                "sha256:1d146a6e798b9e6322825e207b4e0544635e679b69253e6e01a221f45945d2f6"
             ],
             "index": "pypi",
-            "version": "==3.2.0"
+            "version": "==3.3.0"
         },
         "python-dateutil": {
             "hashes": [

--- a/app/services/handlers.py
+++ b/app/services/handlers.py
@@ -66,7 +66,7 @@ def check_refurbished(
             text = f"Found {len(products)} {product}(s):\n\n"
             for p in products:
                 text += \
-                    f"- [{p.name}]({p.url}) at ~{p.previous_price}~ \
+                    f"- <{p.url}|{p.name}> at ~{p.previous_price}~ \
 *{p.price}* (-{p.savings_price})\n"
             _events.append(
                 events.RefurbishedProductAvailable(text=text)

--- a/app/services/handlers.py
+++ b/app/services/handlers.py
@@ -66,7 +66,7 @@ def check_refurbished(
             text = f"Found {len(products)} {product}(s):\n\n"
             for p in products:
                 text += \
-                    f"- {p.name} at ~{p.previous_price}~ \
+                    f"- [{p.name}]({p.url}) at ~{p.previous_price}~ \
 *{p.price}* (-{p.savings_price})\n"
             _events.append(
                 events.RefurbishedProductAvailable(text=text)

--- a/tests/integration/test_refurbished.py
+++ b/tests/integration/test_refurbished.py
@@ -25,12 +25,14 @@ def test_available_products(
     refurbished_adapter.search.side_effect = [[
         Product(
             name='iPad Wi-Fi + Cellular 32GB ricondizionato',
+            url='https://www.apple.com/it/ipad-wifi-32gb',
             price=decimal.Decimal('419.00'),
             previous_price=decimal.Decimal('489.00'),
             savings_price=decimal.Decimal('70.00')
         ), 
         Product(
             name='iPad Wi-Fi + Cellular 128GB ricondizionato',
+            url='https://www.apple.com/it/ipad-wifi-cellular-128gb',
             price=decimal.Decimal('499.00'),
             previous_price=decimal.Decimal('579.00'),
             savings_price=decimal.Decimal('80.00')

--- a/tests/integration/test_refurbished.py
+++ b/tests/integration/test_refurbished.py
@@ -48,8 +48,8 @@ def test_available_products(
     expected_events = [events.RefurbishedProductAvailable(text="""\
 Found 2 ipad(s):
 
-- iPad Wi-Fi + Cellular 32GB ricondizionato at ~489.00~ *419.00* (-70.00)
-- iPad Wi-Fi + Cellular 128GB ricondizionato at ~579.00~ *499.00* (-80.00)
+- [iPad Wi-Fi + Cellular 32GB ricondizionato](https://www.apple.com/it/ipad-wifi-32gb) at ~489.00~ *419.00* (-70.00)
+- [iPad Wi-Fi + Cellular 128GB ricondizionato](https://www.apple.com/it/ipad-wifi-cellular-128gb) at ~579.00~ *499.00* (-80.00)
 """)]
     assert actual_events == expected_events
 

--- a/tests/integration/test_refurbished.py
+++ b/tests/integration/test_refurbished.py
@@ -48,8 +48,8 @@ def test_available_products(
     expected_events = [events.RefurbishedProductAvailable(text="""\
 Found 2 ipad(s):
 
-- [iPad Wi-Fi + Cellular 32GB ricondizionato](https://www.apple.com/it/ipad-wifi-32gb) at ~489.00~ *419.00* (-70.00)
-- [iPad Wi-Fi + Cellular 128GB ricondizionato](https://www.apple.com/it/ipad-wifi-cellular-128gb) at ~579.00~ *499.00* (-80.00)
+- <https://www.apple.com/it/ipad-wifi-32gb|iPad Wi-Fi + Cellular 32GB ricondizionato> at ~489.00~ *419.00* (-70.00)
+- <https://www.apple.com/it/ipad-wifi-cellular-128gb|iPad Wi-Fi + Cellular 128GB ricondizionato> at ~579.00~ *499.00* (-80.00)
 """)]
     assert actual_events == expected_events
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
I want to click and see the product page on the Apple Store when I see an interesting refurbished product on Slack.

### Change description
<!-- What does your code do? -->
 * Upgrade the [refurbished](https://github.com/zmoog/refurbished) library to the version [v0.3.0](https://github.com/zmoog/refurbished/releases/tag/v0.3.0) to get the product URL
 * Add a link to the refurbished product page in the products list

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
Implements #74 

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.