### PR TITLE
Refurbished: messages format should happen in the event handlers

### DIFF
--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -69,7 +69,7 @@ def for_cli():
             handlers.log_summarized_entries,
         ],
         events.RefurbishedProductAvailable: [
-            handlers.log_refurbished_product_available,
+            handlers.log_refurbished_product,
         ],
         events.RefurbishedProductNotAvailable: [
             handlers.log_event,

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -66,10 +66,10 @@ event_handlers = {
 def for_cli():
     event_handlers = {
         events.TogglEntriesSummarized: [
-            handlers.log_entries_summarized,
+            handlers.log_summarized_entries,
         ],
         events.RefurbishedProductAvailable: [
-            handlers.log_event,
+            handlers.log_refurbished_product_available,
         ],
         events.RefurbishedProductNotAvailable: [
             handlers.log_event,

--- a/app/domain/events.py
+++ b/app/domain/events.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from typing import List
+from app.domain.model import Product
 
 
 class Event:
@@ -29,7 +31,9 @@ class IFQIssueDownloadFailed(Event):
 
 @dataclass
 class RefurbishedProductAvailable(Event):
-    text: str
+    store: str
+    product: str
+    products: List[Product]
 
 
 @dataclass

--- a/app/domain/model.py
+++ b/app/domain/model.py
@@ -1,5 +1,8 @@
 import datetime
+import decimal
 from typing import Optional
+
+from pydantic import BaseModel
 
 
 def find_previous_business_day(day: Optional[datetime.date] = None):
@@ -21,3 +24,11 @@ def find_previous_business_day(day: Optional[datetime.date] = None):
         previous_day -= datetime.timedelta(days=1)
 
     return previous_day
+
+
+class Product(BaseModel):
+    name: str
+    url: str
+    price: decimal.Decimal
+    previous_price: decimal.Decimal
+    savings_price: decimal.Decimal

--- a/app/services/handlers.py
+++ b/app/services/handlers.py
@@ -106,7 +106,7 @@ def download_ifq(
         )]
 
 
-def log_entries_summarized(
+def log_summarized_entries(
     event: events.TogglEntriesSummarized,
     uow: UnitOfWork,
     context: Dict[str, Any],
@@ -121,7 +121,7 @@ def log_event(
     context: Dict[str, Any],
 ):
     """"Logs events"""
-    text = str(event)
+    text = repr(event)
     terminal.log(text)
 
 
@@ -159,6 +159,26 @@ def notify_refurbished_product_available(
     text += '\n'
 
     uow.slack.post_message({'text': text}, context)
+
+
+def log_refurbished_product_available(
+    event: events.RefurbishedProductAvailable,
+    uow: UnitOfWork,
+    context: Dict[str, Any],
+):
+    """Log the event to the terminal"""
+
+    text = f"\nFound {len(event.products)} {event.product}(s):\n\n"
+    for p in event.products:
+
+        if p.savings_price == 0:
+            text += f"- {p.name} at *{p.price}*\n"
+        else:
+            text += \
+                f"- {p.name} at *{p.price}* (-{p.savings_price})\n"
+    text += '\n'
+
+    terminal.log(text)
 
 
 def notify_refurbished_product_not_available(

--- a/app/services/handlers.py
+++ b/app/services/handlers.py
@@ -161,7 +161,7 @@ def notify_refurbished_product_available(
     uow.slack.post_message({'text': text}, context)
 
 
-def log_refurbished_product_available(
+def log_refurbished_product(
     event: events.RefurbishedProductAvailable,
     uow: UnitOfWork,
     context: Dict[str, Any],

--- a/tests/integration/test_refurbished.py
+++ b/tests/integration/test_refurbished.py
@@ -44,7 +44,7 @@ Found 2 ipad(s):
 - <https://www.apple.com/it/ipad-wifi-32gb|iPad Wi-Fi + Cellular 32GB ricondizionato> at ~489.00~ *419.00* (-70.00)
 - <https://www.apple.com/it/ipad-wifi-cellular-128gb|iPad Wi-Fi + Cellular 128GB ricondizionato> at *499.00*
 
-`"""
+"""
     }
     slack_adapter.post_message.assert_called_once_with(
         message, {}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
The message formatting is happening in the command handler, but the same Markdown text is not good for both Slack and CLI, they should be formatted differently.

### Change description
<!-- What does your code do? -->
 * Created a new domain model `Product` for the refurbished product data (name, url, price, etc)
 * Updated the `RefurbishedProductAvailable` event replacing the `text` attribute with a list of `Product`s

Now each event handler receives a list of `Product`s, and can format the event accordingly to its own specific requirements (Slack, Telegram or standard output).

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
Resolves #77 

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are properly filled.
* [x] Changes will be merged in `master`.
* [x] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.